### PR TITLE
HTTP Header Inject/Extract

### DIFF
--- a/examples/main.go
+++ b/examples/main.go
@@ -3,10 +3,13 @@ package main
 import (
 	"context"
 	"log"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 
 	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/exporters/stdout/stdouttrace"
+	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.4.0"
@@ -42,8 +45,10 @@ func installPipeline(ctx context.Context) func() {
 			semconv.ServiceNameKey.String("stdout-example"),
 			semconv.ServiceVersionKey.String("0.0.1"),
 		)),
+		sdktrace.WithSampler(sdktrace.AlwaysSample()),
 	)
 	otel.SetTracerProvider(tracerProvider)
+	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}, propagation.Baggage{}))
 
 	return func() {
 		if err := tracerProvider.Shutdown(ctx); err != nil {
@@ -52,8 +57,30 @@ func installPipeline(ctx context.Context) func() {
 	}
 }
 
+func server(l *zap.Logger) string {
+	lg := tracelog.NewLogger(
+		tracelog.WithLogger(l),
+	)
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		lg = lg.FromRequest(r)
+
+		ctx, span := tracer.Start(r.Context(), "http.client")
+		defer span.End()
+
+		l := lg.SetContext(ctx)
+		l.Info("handling HTTP request")
+	}))
+
+	return svr.URL
+}
+
 func main() {
 	ctx := context.Background()
+
+	l, err := zap.NewProduction()
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	flush := installPipeline(ctx)
 	defer flush()
@@ -61,21 +88,34 @@ func main() {
 	ctx, span := tracer.Start(ctx, "sample")
 	defer span.End()
 
-	l, err := zap.NewProduction()
+	lg := tracelog.NewLogger(
+		tracelog.WithLogger(l),
+	)
+
+	lg = lg.SetContext(ctx)
+
+	route, err := url.Parse(server(l))
 	if err != nil {
-		log.Fatal(err)
+		lg.Fatal("failed to parse test server address", zap.Error(err))
+
+		return
 	}
 
-	lg := tracelog.NewLogger(tracelog.WithLogger(l))
+	req, err := http.NewRequest(http.MethodPost, route.String(), nil)
+	if err != nil {
+		lg.Fatal("failed to create HTTP request", zap.Error(err))
+	}
 
-	lg = lg.Context(ctx)
+	request := lg.WithRequest(ctx, req)
 
-	lg.Info(
-		"hello world",
-		attribute.KeyValue{
-			Key:   "trace",
-			Value: attribute.StringValue("value"),
-		},
-		zap.String("log", "value"),
-	)
+	lg.Info("created request")
+
+	resp, err := http.DefaultClient.Do(request)
+	if err != nil {
+		lg.Fatal("failed to execute HTTP request", zap.Error(err))
+
+		return
+	}
+
+	defer resp.Body.Close()
 }


### PR DESCRIPTION
Leverages the `otel` package to extract and inject HTTP headers into incoming/outgoing HTTP requests.